### PR TITLE
remove uvloop 

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,5 @@ SQLAlchemy==2.0.32
 starlette==0.38.4
 typing_extensions==4.12.2
 uvicorn==0.30.6
-uvloop==0.20.0
 watchfiles==0.24.0
 websockets==13.0.1


### PR DESCRIPTION
fixes https://github.com/CJskii/leaderboard-system/issues/3

uvloop is not required by uvicorn it can also use
Options: 'auto', 'asyncio', 'uvloop'. Default: 'auto'.